### PR TITLE
Add ability to specify start of char map.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Usage: docker run --rm -v "${PWD}":/fonts rfbezerra/svg-to-ttf [OPTIONS]
   -g, --gid [GID]               GroupId owner of the destination folder; default is equal to uid
   -i, --input [FOLDER]          Folder where svg glyphs lives; default is ./input
   -n, --name FONT_NAME          Name of the generated font
+  -c, --codepoint [CODEPOINT]   Starting point for the character map, hexadecimal."
   -o, --output [FOLDER]         Destination folder for generated fonts; default is ./FONT_NAME
   -s, --skip_conversion         Skip the conversion from stroke to path
   -u, --uid [UID]               UserId owner of the destination folder; default is 0 (root)


### PR DESCRIPTION
Hi, first of all, thanks for the tool, it's been very useful.

Here I add the ability to modify the character map of the generated font by modifying the codepoints of the manifesto generated by `fontcustom`, the start of the char map can be set as an hexadecimal number with the new option `-c|--codepoint`.

I've found it useful to have control over the character assignment for different reasons; one of them would be that some fonts take control over a section of the char map, which prevent us from using bare unicodes in scripts and files. With this change our fonts won't conflict with existing ones anymore, if we set the charmap accordingly.

